### PR TITLE
使assetPublicPath配置生效

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 function MpvuePlugin() {}
 
 MpvuePlugin.prototype.apply = function(compiler) {
-  const {options: {entry, plugins}} = compiler;
+  const {options: {entry, output: {publicPath}, plugins}} = compiler;
   compiler.plugin('emit', function(compilation, callback) {
     let commonsChunkNames = [];
     // 获取所有的 chunk name
@@ -25,7 +25,7 @@ MpvuePlugin.prototype.apply = function(compiler) {
           try {
             if (compilation.assets[wxssFile]) {
               let wxss = compilation.assets[wxssFile].source();
-              wxss = `@import "/${commonWxssFile}";\n${wxss}`;
+              wxss = `@import "${publicPath}/${commonWxssFile}";\n${wxss}`;
               compilation.assets[wxssFile].source = () => wxss;
             }
           } catch (error) {


### PR DESCRIPTION
当使用mpvue构建原有小程序的分包时，assetsRoot改变后，配置assetsPublicPath不生效
```js
// /config/index.js
module.exports = {
  build: {
    env: require('./prod.env'),
    index: path.resolve(__dirname, '../dist/index.html'),
    assetsRoot: path.resolve(__dirname, '../../dist/register'),//修改了mpvue生成文件的目录
    assetsSubDirectory: 'static',
    assetsPublicPath: '/register',//pubilcPath作出相应修改
    productionSourceMap: false,
    // ...
```
目录结构
```bash
.
├── dist #小程序目录
            ├──register #mpvue生成文件目录
├── project.config.json
└── register #mpvue目录

```